### PR TITLE
add npm and bower version badges (+ create git tags)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Fluorine
 ========
+[![npm-image](https://img.shields.io/npm/v/fluorine.svg?style=flat-square)](https://www.npmjs.com/package/fluorine)
+![bower-image](https://img.shields.io/bower/v/fluorine.svg?style=flat-square)
 
 Fluorine - Flow based programing abstraction.
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fluorine",
   "main": "fluorine.js",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "homepage": "https://github.com/freshout-dev/fluorine",
   "authors": [
     "Fernando Trasviña <trasvina@gmail.com>"


### PR DESCRIPTION
Just added the `npm` and `bower` versions badges to help keep things in sync.

As you can see [here](https://github.com/noeldelgado/fluorine/blob/master/README.md#fluorine) the bower version is `void`, that is because bower versions relies on git-tags and there are [no tags on this repo yet](https://github.com/freshout-dev/fluorine/tags), so I recommend you creating and pushing at least one git-tag for the latest version `v1.0.3`.

Thanks
